### PR TITLE
SHOW-17: Move authentication to only API endpoints

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -72,9 +72,6 @@ func New(conf *Config, auth *auth.Auther, ls *livestream.Livestreamer, mcr *mcr.
 // Start sets up a HTTP server listening.
 func (h *Handlers) Start() {
 	internal := h.mux.Group("")
-	if !h.conf.Debug {
-		internal.Use(middleware.JWTWithConfig(h.jwtConfig))
-	}
 	{
 		// Basic UI endpoints
 		internal.GET("/", h.obsHome)
@@ -127,6 +124,9 @@ func (h *Handlers) Start() {
 
 		// API endpoints
 		api := internal.Group("/api")
+		if !h.conf.Debug {
+			api.Use(middleware.JWTWithConfig(h.jwtConfig))
+		}
 		{
 			api.POST("/livestreams", h.newLivestream)
 			api.PUT("/livestreams", h.updateLivestream)


### PR DESCRIPTION
### Changes

- Moved authenication from UI endpoints to API endpoints

### Notes

So it does seem a bit risky to cover only the API endpoints now. So this is now moving the authentication mechanism to a proxy server to handle, for YSTV's usecase I've updated our config to ensure that all necessary paths are covered

Not a long-term solution, but this will make ShowTime! usable for end-users right now